### PR TITLE
Update Fix CameraSessionManager.h

### DIFF
--- a/src/ios/CameraSessionManager.h
+++ b/src/ios/CameraSessionManager.h
@@ -6,6 +6,7 @@
 - (CameraSessionManager *)init;
 - (void) setupSession:(NSString *)defaultCamera;
 - (void) switchCamera;
+- (void) focusCamera;
 - (void) updateOrientation:(AVCaptureVideoOrientation)orientation;
 - (AVCaptureVideoOrientation) getCurrentOrientation:(UIInterfaceOrientation)toInterfaceOrientation;
 


### PR DESCRIPTION
We cannot build on iOS throwing an error in CameraPreview.m 
Error : CameraPreview.m:108:30: No visible @interface for 'CameraSessionManager' declares the selector 'focusCamera'
